### PR TITLE
Specify workDir (for Go Modules)

### DIFF
--- a/autoload/ctrlp/goimport.vim
+++ b/autoload/ctrlp/goimport.vim
@@ -16,7 +16,7 @@ function! ctrlp#goimport#init()
   if !executable('gopkgs')
     echohl 'Please install gopkgs'
   endif
-  return split(system('gopkgs --no-vendor'), "\n")
+  return split(system('gopkgs --no-vendor --workDir .'), "\n")
 endfunction
 
 function! ctrlp#goimport#accept(mode, str)


### PR DESCRIPTION
This fix adds a support for Go Modules provided by `gopkgs --workDir`.